### PR TITLE
Remove trailing comma from urls list

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
 	  ["lib/aioservice.py", "github:carglglz/asyncmd/aioservice.py"],
 	  ["aioservices/services/__init__.py", "github:carglglz/asyncmd/aioservices/services/__init__.py"]
   ],
-  "deps":[ "logging", "time", "aiorepl"
+  "deps":[
+      ["logging", "latest"],
+      [ "time", "latest" ],
+      [ "aiorepl", "latest" ]
   ],
   "version": "1.0"
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
 	  ["lib/aiolog.py", "github:carglglz/asyncmd/aiolog.py"],
 	  ["lib/aioclass.py", "github:carglglz/asyncmd/aioclass.py"],
 	  ["lib/aioservice.py", "github:carglglz/asyncmd/aioservice.py"],
-	  ["aioservices/services/__init__.py", "github:carglglz/asyncmd/aioservices/services/__init__.py"],
-
+	  ["aioservices/services/__init__.py", "github:carglglz/asyncmd/aioservices/services/__init__.py"]
   ],
   "deps":[ "logging", "time", "aiorepl"
   ],


### PR DESCRIPTION
Top-level package.json doesn't parse as JSON because the "urls" list ends with a comma. This PR fixes the problem by removing the comma.